### PR TITLE
Compile, upload and release debug APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Clone repo and submodules
-      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . #--branch ${{env.Branch}}
+      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . --branch ${{env.Branch}}
 
     - name: Get current date, commit hash and count
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build
+
+env:
+  Artifacts: Android/app/build/outputs/apk/debug/app-debug.apk
+  Branch: ${{github.ref_name}}
+  GH_TOKEN: ${{ github.token }}
+
+on:
+  push:
+    Branches: $Branch
+  pull_request:
+    Branches: $Branch
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone repo and submodules
+      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . #--branch ${{env.Branch}}
+
+    - name: Get current date, commit hash and count
+      run: |
+        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $GITHUB_ENV
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count ${{env.Branch}} --)" >> $GITHUB_ENV
+    
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: |
+        cd Android
+        chmod +x gradlew
+
+    - name: Build with Gradle
+      run:  |
+        cd Android
+        ./gradlew build --warning-mode all
+
+    - name: Upload Artifact to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: "${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        path: "${{github.workspace}}/${{env.Artifacts}}"
+
+    - name: Release
+      run: |
+        gh release create r${{env.CommitCount}} --generate-notes --latest=false --title "[${{env.CommitDate}}] ${{github.event.repository.name}} r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        gh release upload r${{env.CommitCount}} "${{env.Artifacts}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $GITHUB_ENV
         echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
-        echo "CommitCount=$(git rev-list --count ${{env.Branch}} --)" >> $GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count HEAD)" >> $GITHUB_ENV
     
     - name: set up JDK 17
       uses: actions/setup-java@v3

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -28,6 +28,9 @@ android {
             path 'src/main/jni/CMakeLists.txt'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Automated GitHub actions CI
Debug APK uploaded into the workflow here https://github.com/ThreeDeeJay/SuperpoweredLatency/actions/runs/11024933723
And releases for more visibility and no expiration: https://github.com/ThreeDeeJay/SuperpoweredLatency/releases/latest

Maybe it could be signed with a signature stored as a GitHub action [secret variable](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) for a proper release but I'm not sure how to do that  programmatically.